### PR TITLE
Explicit imports

### DIFF
--- a/spharpy/__init__.py
+++ b/spharpy/__init__.py
@@ -8,3 +8,13 @@ from . import plot
 from . import indexing
 from . import transforms
 from . import beamforming
+
+
+__all__ = [
+    'spherical',
+    'samplings',
+    'plot',
+    'indexing',
+    'transforms',
+    'beamforming',
+]

--- a/spharpy/beamforming/__init__.py
+++ b/spharpy/beamforming/__init__.py
@@ -1,3 +1,11 @@
-from .beamforming import dolph_chebyshev_weights
-from .beamforming import rE_max_weights
-from .beamforming import maximum_front_back_ratio_weights
+from .beamforming import (
+    dolph_chebyshev_weights,
+    rE_max_weights,
+    maximum_front_back_ratio_weights
+)
+
+__all__ = [
+    'dolph_chebyshev_weights',
+    'rE_max_weights',
+    'maximum_front_back_ratio_weights',
+]

--- a/spharpy/indexing/__init__.py
+++ b/spharpy/indexing/__init__.py
@@ -1,1 +1,3 @@
-from .channel_indexing import *
+from .channel_indexing import sid2acn, sid, sph_identity_matrix
+
+__all__ = ['sid2acn', 'sid', 'sph_identity_matrix']

--- a/spharpy/plot/__init__.py
+++ b/spharpy/plot/__init__.py
@@ -1,1 +1,27 @@
-from .spatial import *
+from .spatial import (
+    scatter,
+    pcolor_map,
+    pcolor_sphere,
+    balloon,
+    balloon_wireframe,
+    voronoi_cells_sphere,
+    contour,
+    contour_map,
+    MidpointNormalize,
+)
+
+from .cmap import phase_twilight
+
+
+__all__ = [
+    'scatter',
+    'pcolor_map',
+    'pcolor_sphere',
+    'balloon',
+    'balloon_wireframe',
+    'voronoi_cells_sphere',
+    'contour',
+    'contour_map',
+    'MidpointNormalize',
+    'phase_twilight',
+]

--- a/spharpy/plot/spatial.py
+++ b/spharpy/plot/spatial.py
@@ -14,6 +14,8 @@ from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from packaging import version
 from scipy.stats import circmean
 
+from .cmap import phase_twilight
+
 from spharpy.samplings import (Coordinates, latlon2cart, sph2cart,
                                spherical_voronoi)
 
@@ -780,35 +782,3 @@ class MidpointNormalize(colors.Normalize):
         # simple example...
         x, y = [self.vmin, self.midpoint, self.vmax], [0, 0.5, 1]
         return np.ma.masked_array(np.interp(value, x, y))
-
-
-def phase_twilight(lut=512):
-    r"""
-    Cyclic colormap for phase plots. Assuming angles in the
-    interval [0, $2\pi$], 0 radians (+1) will be red, while $\pi$ radians (-1)
-    will be represented in blue.
-
-    Parameters
-    ----------
-    lut : int (512)
-        Number of entries in the look up table for interpolation
-
-    Returns
-    -------
-    cmap : ListedColormap
-        Matplotlib ListedColormap object
-
-    Note
-    ----
-    The function implements a shifted version of the twilight colormap from
-    matplotlib >= 3.0
-    """
-    lut = int(np.ceil(lut/4)*4)
-    twilight = cm.get_cmap('twilight', lut=lut)
-
-    twilight_r_colors = np.array(twilight.reversed().colors)
-
-    roll_by = int(lut/4)
-    phase_colors = np.roll(twilight_r_colors, -roll_by, axis=0)
-
-    return ListedColormap(phase_colors)

--- a/spharpy/samplings/__init__.py
+++ b/spharpy/samplings/__init__.py
@@ -1,6 +1,49 @@
-from .samplings import *
-from .helpers import *
+from .samplings import (
+    cube_equidistant,
+    hyperinterpolation,
+    spherical_t_design,
+    dodecahedron,
+    icosahedron,
+    icosahedron_ke4,
+    equiangular,
+    gaussian,
+    eigenmike_em32,
+    equalarea,
+    spiral_points)
+
+from .helpers import (
+    sph2cart,
+    cart2sph,
+    cart2latlon,
+    latlon2cart,
+    spherical_voronoi,
+    calculate_sampling_weights
+)
 
 from .coordinates import Coordinates, SamplingSphere
 
 from .interior import interior_stabilization_points
+
+
+__all__ = [
+    'cube_equidistant',
+    'hyperinterpolation',
+    'spherical_t_design',
+    'dodecahedron',
+    'icosahedron',
+    'icosahedron_ke4',
+    'equiangular',
+    'gaussian',
+    'eigenmike_em32',
+    'equalarea',
+    'spiral_points',
+    'sph2cart',
+    'cart2sph',
+    'cart2latlon',
+    'latlon2cart',
+    'spherical_voronoi',
+    'calculate_sampling_weights',
+    'Coordinates',
+    'SamplingSphere',
+    'interior_stabilization_points',
+]

--- a/spharpy/spatial/__init__.py
+++ b/spharpy/spatial/__init__.py
@@ -1,1 +1,4 @@
-from .spatial import *
+from .spatial import greens_function_plane_wave, greens_function_point_source
+
+
+__all__ = 'greens_function_plane_wave', 'greens_function_point_source'

--- a/spharpy/transforms/__init__.py
+++ b/spharpy/transforms/__init__.py
@@ -1,1 +1,4 @@
-from .rotations import *
+from .rotations import rotation_z_axis, rotation_z_axis_real
+
+
+__all__ = 'rotation_z_axis', 'rotation_z_axis_real'


### PR DESCRIPTION
Make imports more explicit avoiding `from .module import *`