### PR TITLE
Drop support for python 3.8 and require numpy>=1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"
@@ -147,7 +146,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ spharpy
     :target: https://circleci.com/gh/mberz/spharpy
 .. image:: https://mybinder.org/badge_logo.svg
     :target: https://mybinder.org/v2/gh/mberz/spharpy/main?filepath=examples/
-    
+
 Spherical array processing in python.
 
 
@@ -23,8 +23,6 @@ Use pip to install spharpy
 .. code-block:: console
 
     $ pip install spharpy
-
-Python versions >= 3.7 are required
 
 
 Getting Started

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-scipy
-numpy
-setuptools
-pytest
-urllib3
-cython
-matplotlib

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 scipy
-numpy
+numpy>=1.22
 setuptools
 pytest
 urllib3

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     test_suite='tests',
     tests_require=test_requirements,
@@ -64,5 +65,5 @@ setup(
         "Documentation": "https://spharpy.readthedocs.io/",
         "Source Code": "https://github.com/mberz/spharpy",
     },
-    python_requires='>=3.7'
+    python_requires='>=3.8'
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'numpy',
+    'numpy>=1.22',
     'scipy',
     'urllib3',
     'matplotlib<3.4'


### PR DESCRIPTION
Drop support for python 3.8 and require numpy>=1.22

This is in line with pyfar and avoids security issues reported in numpy<1.22.