### PR TITLE
Bugfix: rounding for values smallter than eps in sph2cart

### DIFF
--- a/spharpy/samplings/helpers.py
+++ b/spharpy/samplings/helpers.py
@@ -38,7 +38,14 @@ def sph2cart(r, theta, phi):
     x = r*np.sin(theta)*np.cos(phi)
     y = r*np.sin(theta)*np.sin(phi)
     z = r*np.cos(theta)
-    return x, y, z
+    x = np.asarray(x)
+    y = np.asarray(y)
+    z = np.asarray(z)
+    x[np.abs(x) <= np.finfo(x.dtype).eps] = 0
+    y[np.abs(y) <= np.finfo(y.dtype).eps] = 0
+    z[np.abs(z) <= np.finfo(x.dtype).eps] = 0
+
+    return np.squeeze(x), np.squeeze(y), np.squeeze(z)
 
 
 def cart2sph(x, y, z):

--- a/tests/test_coordinate_transforms.py
+++ b/tests/test_coordinate_transforms.py
@@ -5,6 +5,7 @@ import numpy as np
 import spharpy.samplings as samplings
 from spharpy.samplings import spherical_voronoi
 
+
 def test_sph2cart():
     rad, theta, phi = 1, np.pi/2, 0
     x, y, z = samplings.sph2cart(rad, theta, phi)
@@ -40,6 +41,7 @@ def test_cart2sph_array():
     np.testing.assert_allclose(rad, rr, atol=1e-15)
     np.testing.assert_allclose(phi, pp, atol=1e-15)
     np.testing.assert_allclose(theta, tt, atol=1e-15)
+
 
 def test_cart2latlon_array():
     x = np.array([1, -1, 0, 0, 0, 0])


### PR DESCRIPTION
Rounding issues may lead to large angular errors between Cartesian coordinate axes smaller than the eps limit.
This is only relevant when converting between different spherical coordinate systems.
